### PR TITLE
add endpoint for retrieving requests for customers and agents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 # knock for authentication
 gem 'knock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     puma (4.3.2)
       nio4r (~> 2.0)
     rack (2.2.2)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)
@@ -235,6 +236,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.2, >= 6.0.2.1)
   rspec-rails
   shoulda-matchers

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,9 +1,9 @@
 module Response
-  def json_response(object, message, status=:ok)
+  def json_response(object, extra, status=:ok)
     object = ActiveModelSerializers::SerializableResource.new(object).as_json
     response = {
       data: object,
-      message: message
+      extra: extra
     }
     render json: response, status: status
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -4,6 +4,15 @@ class Customer < User
 
   before_save :set_uid
 
+  # using counter cache might not work here since I want more granularity
+  def open_requests_count
+    support_requests.where("status = ? OR status = ?", 'opened', 'assigned').count
+  end
+
+  def resolved_requests_count
+    support_requests.where(status: 'resolved').count
+  end
+
   private
 
   def set_uid

--- a/app/models/support_agent.rb
+++ b/app/models/support_agent.rb
@@ -4,6 +4,15 @@ class SupportAgent < User
 
   before_save :set_uid
 
+  # using counter cache might not work here since I want more granularity
+  def open_requests_count
+    support_requests.where("status = ? OR status = ?", 'opened', 'assigned').count
+  end
+
+  def resolved_requests_count
+    support_requests.where(status: 'resolved').count
+  end
+
   private
   def set_uid
     self.uid = generate_uid(self.type)

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -16,6 +16,8 @@ class SupportRequest < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
+  scope :open, -> { where(status: 'opened') }
+
   validates_presence_of :subject, :description
 
   enum status: {

--- a/app/serializers/support_request_serializer.rb
+++ b/app/serializers/support_request_serializer.rb
@@ -4,8 +4,18 @@ class SupportRequestSerializer < ActiveModel::Serializer
              :description,
              :status,
              :requester_id,
-             :assignee_id
+             :assignee_id,
+             :created_at,
+             # :resolved_count
   def id
     object.uid
+  end
+
+  def status
+    object.status.capitalize
+  end
+
+  def resolved_count
+    SupportRequest.where(status: 'resolved')
   end
 end

--- a/app/services/support_request_service.rb
+++ b/app/services/support_request_service.rb
@@ -25,4 +25,12 @@ class SupportRequestService
       ).assign_request.deliver_later
     @support_request
   end
+
+  def self.fetch_requests(resource, query="")
+    unless query.blank?
+      return resource.support_requests
+                           .where("status = ?", query)
+    end
+    resource.support_requests
+  end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,12 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  resources :customers, only: %i[create]
-  resources :support_agents, only: %i[create index]
+  resources :customers, only: %i[create] do
+    resources :support_requests, only: %i[index]
+  end
+  resources :support_agents, only: %i[create index] do
+    resources :support_requests, only: %i[index]
+  end
   resources :support_requests, only: %i[create show index] do
     resources :comments, only: %i[create index]
     member do

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AdminsController, type: :request do
       it "assigns the request to a support agent" do
         returned_request = json["data"]["support_request"]
         expect(response).to have_http_status 200
-        expect(returned_request["status"]).to eq "assigned"
+        expect(returned_request["status"]).to eq "Assigned"
         expect(returned_request["assignee_id"]).to eq support_agent.id
       end
 

--- a/spec/requests/support_requests_spec.rb
+++ b/spec/requests/support_requests_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe SupportRequestsController, type: :request do
   let(:support_request) { FactoryBot.attributes_for(:support_request) }
   let(:created_request) { FactoryBot.create(:support_request) }
   let(:customer) { FactoryBot.create(:customer) }
+  let(:support_agent) { FactoryBot.create(:support_agent) }
 
   describe "post /support_requests" do
     context "when valid parameters are passed" do
@@ -16,7 +17,7 @@ RSpec.describe SupportRequestsController, type: :request do
       it "creates the request" do
         returned_request = json["data"]["support_request"]
         expect(response).to have_http_status(201)
-        expect(returned_request["status"]).to eq "opened"
+        expect(returned_request["status"]).to eq "Opened"
         expect(returned_request["requester_id"]).to eq customer.id
         expect(SupportRequest.last.description).to eq support_request[:description]
       end
@@ -66,6 +67,89 @@ RSpec.describe SupportRequestsController, type: :request do
         errors = json["errors"].first
         expect(response).to have_http_status 404
         expect(errors["messages"]).to eq "Resource was not found"
+      end
+    end
+  end
+
+  describe "/customers/:customer_id/requests" do
+    let!(:new_requests) { FactoryBot.create_list(:support_request, 5, requester_id: customer.id) }
+    context "when a valid customer id is passed" do
+      before do
+        get customer_support_requests_path(customer.id),
+            headers: authenticated_headers(customer.id)
+      end
+      it "returns the appropriate requests" do
+        returned_requests = json["data"]["support_requests"]
+        expect(response).to have_http_status  200
+        expect(returned_requests.count).to eq 5
+        statuses = returned_requests.pluck("status")
+        expect(statuses.uniq.count).to eq 1
+      end
+    end
+  end
+
+  describe "/support_agents/:support_agent_id/requests" do
+    let!(:new_requests) { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id) }
+    context "when a valid support agent id is passed" do
+      before do
+        get support_agent_support_requests_path(support_agent.id),
+            headers: authenticated_headers(support_agent.id)
+      end
+      it "returns the appropriate requests" do
+        returned_requests = json["data"]["support_requests"]
+        expect(response).to have_http_status  200
+        expect(returned_requests.count).to eq 5
+        statuses = returned_requests.pluck("status")
+        expect(statuses.uniq.count).to eq 1
+      end
+    end
+  end
+
+  describe "query string" do
+    let!(:assigned_requests)  { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id, status: 'resolved') }
+    let!(:opened_requests)  { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id, status: 'opened') }
+
+    context "when query string is present" do
+      before do
+        get support_agent_support_requests_path(support_agent.id),
+            headers: authenticated_headers(support_agent.id),
+            params: { query: 'opened' }
+      end
+
+      it "returns only requests matching the query string" do
+        returned_requests = json["data"]["support_requests"]
+        expect(response).to have_http_status 200
+        expect(returned_requests.count).to eq 5
+        statuses = returned_requests.pluck("status").uniq
+        expect(statuses.count).to eq 1
+        expect(statuses).to include "Opened"
+      end
+    end
+
+    context "when no query sting is passed" do
+      before do
+        get support_agent_support_requests_path(support_agent.id),
+            headers: authenticated_headers(support_agent.id)
+      end
+
+      it "returns all the support requests" do
+        returned_requests = json["data"]["support_requests"]
+        expect(response).to have_http_status 200
+        expect(returned_requests.count).to eq 10
+      end
+    end
+
+    context "when an invalid query string is passed" do
+      before do
+        get support_agent_support_requests_path(support_agent.id),
+            headers: authenticated_headers(support_agent.id),
+            params: { query: 'weird' }
+      end
+
+      it "returns an empty result set" do
+        returned_requests = json["data"]["support_requests"]
+        expect(response).to have_http_status 200
+        expect(returned_requests.count).to eq 0
       end
     end
   end

--- a/spec/services/support_request_service_spec.rb
+++ b/spec/services/support_request_service_spec.rb
@@ -43,4 +43,33 @@ RSpec.describe SupportRequestService, type: :service do
       end
     end
   end
+
+  describe "self.fetch_request" do
+    let!(:assigned_requests)  { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id, status: 'resolved') }
+    let!(:opened_requests)  { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id, status: 'opened') }
+
+    context "when a query string is present" do
+      it "returns a matching result set" do
+        sp = SupportRequestService.fetch_requests(support_agent, "opened")
+        expect(sp.count).to eq 5
+        statuses = sp.pluck(:status).uniq
+        expect(statuses.count).to eq 1
+        expect(statuses).to include "opened"
+      end
+    end
+
+    context "when a query string is not present" do
+      it "returns a matching result set" do
+        sp = SupportRequestService.fetch_requests(support_agent)
+        expect(sp.count).to eq 10
+      end
+    end
+
+    context "when an invalid status is passed as a query" do
+      it "returns an empty result set" do
+        sp = SupportRequestService.fetch_requests(support_agent, "weird")
+        expect(sp.count).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
  - add singleton method for retrieving events to support_request_service.rb
  - change `messages` key to `extra` in response.rb
  - add methods for retrieving counts of open and closed requests for both customers and support agents