### PR TITLE
add priority to support requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ AllCops:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/WordArray:
+  Enabled: false

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,5 +1,11 @@
 module Response
   def json_response(object, extra, status=:ok)
+    if object.is_a? Hash
+      object.transform_values! do |value|
+        ActiveModelSerializers::SerializableResource.new(value).as_json
+      end
+    end
+
     object = ActiveModelSerializers::SerializableResource.new(object).as_json
     response = {
       data: object,

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -21,6 +21,11 @@ class SupportRequestsController < ApplicationController
     })
   end
 
+  def group_by_priority
+    requests = SupportRequestService.group_by_priority(authenticate_resources)
+    json_response(requests, "")
+  end
+
   def show
     json_response(@support_request, "")
   end

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -28,6 +28,12 @@ class SupportRequest < ApplicationRecord
     resolved: "resolved"
   }
 
+  enum priority: {
+    low: "low",
+    normal: "normal",
+    high: "high"
+  }
+
   before_create :set_uid
 
   def self.to_csv

--- a/app/serializers/support_request_serializer.rb
+++ b/app/serializers/support_request_serializer.rb
@@ -3,6 +3,7 @@ class SupportRequestSerializer < ActiveModel::Serializer
              :subject,
              :description,
              :status,
+             :priority,
              :requester_id,
              :assignee_id,
              :created_at,

--- a/app/services/support_request_service.rb
+++ b/app/services/support_request_service.rb
@@ -26,13 +26,17 @@ class SupportRequestService
     @support_request
   end
 
-  def self.fetch_requests(resource, query="")
+  def self.fetch_requests(resource, query = "")
     unless query.blank?
       return resource.support_requests
                            .where("status = ?", query)
 
     end
     resource.support_requests
+  end
 
+  # call fetch requests first and then group
+  def self.group_by_priority(resource)
+    fetch_requests(resource).group_by(&:priority)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,19 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   resources :customers, only: %i[create] do
-    resources :support_requests, only: %i[index]
+    resources :support_requests, only: %i[index] do
+      get "/priorities", to: "support_requests#group_by_priority", on: :collection
+    end
   end
   resources :support_agents, only: %i[create index] do
     resources :support_requests, only: %i[index]
   end
   resources :support_requests, only: %i[create show index] do
     resources :comments, only: %i[create index]
-    get '/export', to: "support_requests#export_as_csv", on: :collection
+    collection do
+      get "/export", to: "support_requests#export_as_csv"
+      get "/priorities", to: "support_requests#group_by_priority"
+    end
     member do
       patch '/assign', to: "admins#assign"
       patch 'resolve', to: "support_requests#resolve"

--- a/db/migrate/20200508054039_add_priority_to_support_requests.rb
+++ b/db/migrate/20200508054039_add_priority_to_support_requests.rb
@@ -1,0 +1,11 @@
+class AddPriorityToSupportRequests < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      ALTER TABLE support_requests ADD priority enum("low", "normal", "high") DEFAULT "normal";
+    SQL
+  end
+
+  def down
+    remove_column :support_requests, :priority
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_02_165508) do
+ActiveRecord::Schema.define(version: 2020_05_08_054039) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "body"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_03_02_165508) do
     t.datetime "updated_at", precision: 6, null: false
     t.column "status", "enum('opened','assigned','resolved')", default: "opened"
     t.string "uid", null: false
+    t.column "priority", "enum('low','normal','high')", default: "normal"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,8 @@ customers = Customer.first(5).pluck(:id)
   SupportRequest.create!(
     subject: Faker::Lorem.word,
     description: Faker::Lorem.paragraph(sentence_count: 1),
-    requester_id: customers.sample
+    requester_id: customers.sample,
+    priority: ["low", "normal", "high"].sample
   )
 end
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,10 @@
+namespace :data_migrations do
+  desc "TODO"
+  task add_priority_to_support_requests: :environment do
+    requests = SupportRequest.where(priority: nil)
+
+    requests.each do |req|
+      req.update!(priority: "normal")
+    end
+  end
+end

--- a/spec/factories/support_requests.rb
+++ b/spec/factories/support_requests.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     resolved_at { nil }
     requester_id { create(:customer).id }
     assignee_id { nil }
+    priority { ["low", "high", "normal"].sample }
   end
 end

--- a/spec/services/support_request_service_spec.rb
+++ b/spec/services/support_request_service_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe SupportRequestService, type: :service do
   let(:customer) { FactoryBot.create(:customer) }
+  let(:admin) { FactoryBot.create(:admin) }
   let(:support_request) { FactoryBot.create(:support_request) }
   let(:support_agent) { FactoryBot.create(:support_agent) }
   let(:params) { FactoryBot.attributes_for(:support_request) }
@@ -69,6 +70,22 @@ RSpec.describe SupportRequestService, type: :service do
       it "returns an empty result set" do
         sp = SupportRequestService.fetch_requests(support_agent, "weird")
         expect(sp.count).to eq 0
+      end
+    end
+  end
+
+  describe ".group_by_priority" do
+    let!(:requests) { FactoryBot.create_list(:support_request, 20) }
+    context "when a call is made" do
+      it "returns requests grouped by priority" do
+        requests = SupportRequestService.group_by_priority(admin)
+        expect(requests).to be_a Hash
+        expect(requests).to have_key "low"
+        expect(requests).to have_key "normal"
+        expect(requests).to have_key "high"
+        total_count = 0
+        requests.each_value { |value| total_count += value.count }
+        expect(total_count).to eq 20
       end
     end
   end


### PR DESCRIPTION
  - add new priority column to support requests table
  - add data migration to set priority values for old columns
  - modify seeds to use priority
  - add `priority` to support_request_serializer.rb
  - add a group_by_priority method to support_request_service.rb
  - add tests
  - add routes

 misc
   - modify response.rb to serialize values in a hash

To test, send a request to `http://localhost:3000//support_requests/priorities`