### PR TITLE
Ft automatically assign requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,11 @@ gem 'puma', '~> 4.1'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# counter cache gem to help with conditional caches
+gem "counter_culture", "~> 2.0"
+# faker gem
+gem "faker"
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
@@ -40,7 +45,6 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'guard'
   gem 'guard-rspec',  require: false
-  gem 'faker'
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     bcrypt (3.1.13)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -71,6 +74,10 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
+    counter_culture (2.4.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      after_commit_action (~> 1.0)
     crass (1.0.6)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -243,6 +250,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   bootsnap (>= 1.4.2)
   byebug
+  counter_culture (~> 2.0)
   database_cleaner
   factory_bot_rails
   faker

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -5,10 +5,11 @@ class AdminsController < ApplicationController
 
   def assign
     support_request = SupportRequestService
-                        .new(
-                          request_params: params,
-                          support_request: @support_request
-                        ).assign_request
+                        .new
+                        .assign_request(
+                          request_id: params[:id],
+                          assignee_id: params[:assignee_id]
+                        )
     json_response(support_request, "Request assigned successfully")
   end
 

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -38,7 +38,7 @@ class SupportRequestsController < ApplicationController
   end
 
   def export_as_csv
-    SupportRequestWorker.perform_async(current_support_agent.id)
+    ExportRequestsWorker.perform_async(current_support_agent.id)
     json_response({}, "Generated requests have been sent to your mail")
   end
 
@@ -58,5 +58,9 @@ class SupportRequestsController < ApplicationController
   # run authentications for both customers and support_agents
   def authenticate_resources
     authenticate_for(SupportAgent) || authenticate_for(Customer) || authenticate_for(Admin)
+  end
+
+  def trigger_assign_requests_worker
+    AssignRequestsWorker
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,4 +10,10 @@ class AdminMailer < ApplicationMailer
          bcc: admin_emails
     )
   end
+
+  def no_available_agent
+    @support_request_id = params[:support_request_id]
+    admin_emails = Admin.all.pluck(:email)
+    mail(to: admin_emails, subject: "No available agent")
+  end
 end

--- a/app/models/concerns/generate_uid.rb
+++ b/app/models/concerns/generate_uid.rb
@@ -3,13 +3,21 @@ module GenerateUid
 
   def generate_uid(klass)
     base_klass = klass.constantize
-    token = "#{klass[0..3].downcase}-#{SecureRandom.hex}"
+    token = "#{set_identifier(klass)}-#{SecureRandom.hex}"
     token_exists = base_klass.find_by(uid: token)
 
     while token_exists
-      token = "#{klass[0..3].downcase}-#{SecureRandom.hex}"
+      token = "#{set_identifier(klass)}-#{SecureRandom.hex}"
       token_exists = base_klass.find_by(uid: token)
     end
     token
+  end
+
+  private
+
+  def set_identifier(klass)
+    return "request" if klass == "SupportRequest"
+
+    klass[0..3].downcase
   end
 end

--- a/app/models/support_request.rb
+++ b/app/models/support_request.rb
@@ -2,7 +2,6 @@ require 'csv'
 class SupportRequest < ApplicationRecord
   include GenerateUid
   self.primary_key = 'uid'
-  delegate :customer, :support_agent, to: :users
 
   belongs_to :customer,
              class_name: 'User',
@@ -13,6 +12,8 @@ class SupportRequest < ApplicationRecord
              class_name: 'User',
              foreign_key: 'assignee_id',
              optional: true
+  counter_culture :support_agent,
+                  column_name: proc { |model| model.status == "assigned" ? "support_requests_count" : nil }
 
   has_many :comments, primary_key: 'uid'
 

--- a/app/services/support_request_service.rb
+++ b/app/services/support_request_service.rb
@@ -14,16 +14,17 @@ class SupportRequestService
     end
   end
 
-  def assign_request
-    @support_request
-      .update(assignee_id: @request_params[:assignee_id], status: 'assigned')
+  def assign_request(request_id:, assignee_id:)
+    support_request = SupportRequest.find_by!(uid: request_id)
+    support_request
+      .update(assignee_id: assignee_id, status: "assigned")
 
     AdminMailer
       .with(
-        assignee_id: @request_params[:assignee_id],
-        support_request_id: @request_params[:id]
+        assignee_id: assignee_id,
+        support_request_id: request_id
       ).assign_request.deliver_later
-    @support_request
+    support_request
   end
 
   def self.fetch_requests(resource, query = "")

--- a/app/services/support_request_service.rb
+++ b/app/services/support_request_service.rb
@@ -8,6 +8,7 @@ class SupportRequestService
   def create
     support_request = @customer.support_requests.create!(@request_params)
     support_request.tap do |req|
+      AssignRequestsWorker.perform_async(req.id)
       CustomerMailer
         .with(customer_id: @customer.id, support_request_id: req.id)
         .open_request.deliver_later

--- a/app/views/admin_mailer/no_available_agent.html.erb
+++ b/app/views/admin_mailer/no_available_agent.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<h1>Greetings Admin</h1>
+<p>
+  This request with ID <%= link_to "##{@support_request_id}", support_request_url(@support_request_id) %>
+  can't be assigned to an agent as they are all occupied.
+  <br />
+  Please assign this manually or wait till an agent has resolved a task
+</p>
+</body>
+</html>

--- a/app/workers/assign_requests_worker.rb
+++ b/app/workers/assign_requests_worker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# worker for assigning requests
+class AssignRequestsWorker
+  include Sidekiq::Worker
+  sidekiq_options(retry: 1)
+
+  def perform(request_id:)
+    agents = available_agents
+    open_request_notifier if agents.empty?
+    SupportRequestService
+      .new
+      .assign_request(request_id: request_id, assignee_id: agents.first.id)
+  end
+
+  private
+
+  def available_agents
+    SupportAgent
+      .where("support_requests_count < ?", 5)
+      .order(support_requests_count: :asc)
+  end
+
+  # if there's no agent to handle a request. Send a mail to admin with it
+
+  def open_request_notifier
+    p "Yay for now"
+  end
+end

--- a/db/migrate/20200510033101_add_support_requests_count_to_users.rb
+++ b/db/migrate/20200510033101_add_support_requests_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddSupportRequestsCountToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :support_requests_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_054039) do
+ActiveRecord::Schema.define(version: 2020_05_10_033101) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "body"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_054039) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
     t.string "uid", null: false
+    t.integer "support_requests_count", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -7,4 +7,14 @@ namespace :data_migrations do
       req.update!(priority: "normal")
     end
   end
+
+  task update_open_requests_count: :environment do
+    agents = SupportAgent.includes(:support_requests)
+
+    agents.each do |agent|
+      agent.update!(
+        support_requests_count: agent.support_requests.assigned.count
+      )
+    end
+  end
 end

--- a/public/requests/-3-2020-request
+++ b/public/requests/-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-098643efee4ef5bcc8bbbda7dbd3d672-3-2020-request
+++ b/public/requests/supp-098643efee4ef5bcc8bbbda7dbd3d672-3-2020-request
@@ -1,8 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid
-1,Repairs,Test mailerTest mailerTest mailerTest mailerTest mailerTest mailer,2020-03-09 13:09:13 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 15:40:28 UTC,2020-03-09 13:09:13 UTC,resolved,request-d34fc047e1968ac9ee96ac043fa283d3
-2,Repairs,Test mailer,2020-03-09 13:11:26 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:02:17 UTC,2020-03-09 13:11:26 UTC,resolved,request-9e1a58fc6154362c4424ce7fd5ecdc9e
-3,Repairs,Test mailer,2020-03-09 13:20:46 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:05:50 UTC,2020-03-09 13:20:46 UTC,resolved,request-9a8035f4074da88648655099a6c97a4e
-4,Tech,Tech,2020-03-09 13:23:40 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:32:36 UTC,2020-03-09 13:23:40 UTC,resolved,request-ed63ab46d588fe9f438c8f67c3e9710a
-5,Retro,Everything is broken,2020-03-09 13:26:05 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:36:58 UTC,2020-03-09 13:26:05 UTC,resolved,request-c9f3c5ae9ccf9a7abb1b9d3b21553fc0
-7,Retro,ret,2020-03-09 13:29:00 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:47:42 UTC,2020-03-09 15:21:05 UTC,assigned,request-ed21b355c219929c46cdb690611ad10a
-8,Tech,Tech,2020-03-09 13:37:45 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:49:09 UTC,2020-03-09 13:37:45 UTC,resolved,request-2e97ed35e3feb2fc9b47e320e17608ec

--- a/public/requests/supp-1fbeaf2bc5c19f97d517e012ca48522d-3-2020-request
+++ b/public/requests/supp-1fbeaf2bc5c19f97d517e012ca48522d-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-21fbd57cac28a036e408f8fa778d55a8-3-2020-request
+++ b/public/requests/supp-21fbd57cac28a036e408f8fa778d55a8-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-4e9316af82f2249fd3e65b4c1714379c-3-2020-request
+++ b/public/requests/supp-4e9316af82f2249fd3e65b4c1714379c-3-2020-request
@@ -1,8 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid
-1,Repairs,Test mailerTest mailerTest mailerTest mailerTest mailerTest mailer,2020-03-09 13:09:13 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 15:40:28 UTC,2020-03-09 13:09:13 UTC,resolved,request-d34fc047e1968ac9ee96ac043fa283d3
-2,Repairs,Test mailer,2020-03-09 13:11:26 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:02:17 UTC,2020-03-09 13:11:26 UTC,resolved,request-9e1a58fc6154362c4424ce7fd5ecdc9e
-3,Repairs,Test mailer,2020-03-09 13:20:46 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:05:50 UTC,2020-03-09 13:20:46 UTC,resolved,request-9a8035f4074da88648655099a6c97a4e
-4,Tech,Tech,2020-03-09 13:23:40 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:32:36 UTC,2020-03-09 13:23:40 UTC,resolved,request-ed63ab46d588fe9f438c8f67c3e9710a
-5,Retro,Everything is broken,2020-03-09 13:26:05 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:36:58 UTC,2020-03-09 13:26:05 UTC,resolved,request-c9f3c5ae9ccf9a7abb1b9d3b21553fc0
-7,Retro,ret,2020-03-09 13:29:00 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:47:42 UTC,2020-03-09 15:21:05 UTC,assigned,request-ed21b355c219929c46cdb690611ad10a
-8,Tech,Tech,2020-03-09 13:37:45 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:49:09 UTC,2020-03-09 13:37:45 UTC,resolved,request-2e97ed35e3feb2fc9b47e320e17608ec

--- a/public/requests/supp-5dceea6df30286a35990cbfbef56c714-3-2020-request
+++ b/public/requests/supp-5dceea6df30286a35990cbfbef56c714-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-66708a4271fe0e79e8e08638b9d2f02c-3-2020-request
+++ b/public/requests/supp-66708a4271fe0e79e8e08638b9d2f02c-3-2020-request
@@ -1,8 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid
-1,Repairs,Test mailerTest mailerTest mailerTest mailerTest mailerTest mailer,2020-03-09 13:09:13 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 15:40:28 UTC,2020-03-09 13:09:13 UTC,resolved,request-d34fc047e1968ac9ee96ac043fa283d3
-2,Repairs,Test mailer,2020-03-09 13:11:26 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:02:17 UTC,2020-03-09 13:11:26 UTC,resolved,request-9e1a58fc6154362c4424ce7fd5ecdc9e
-3,Repairs,Test mailer,2020-03-09 13:20:46 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:05:50 UTC,2020-03-09 13:20:46 UTC,resolved,request-9a8035f4074da88648655099a6c97a4e
-4,Tech,Tech,2020-03-09 13:23:40 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:32:36 UTC,2020-03-09 13:23:40 UTC,resolved,request-ed63ab46d588fe9f438c8f67c3e9710a
-5,Retro,Everything is broken,2020-03-09 13:26:05 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:36:58 UTC,2020-03-09 13:26:05 UTC,resolved,request-c9f3c5ae9ccf9a7abb1b9d3b21553fc0
-7,Retro,ret,2020-03-09 13:29:00 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:47:42 UTC,2020-03-09 15:21:05 UTC,assigned,request-ed21b355c219929c46cdb690611ad10a
-8,Tech,Tech,2020-03-09 13:37:45 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:49:09 UTC,2020-03-09 13:37:45 UTC,resolved,request-2e97ed35e3feb2fc9b47e320e17608ec

--- a/public/requests/supp-78ec97010230c4a452b9af0e4bdf9077-3-2020-request
+++ b/public/requests/supp-78ec97010230c4a452b9af0e4bdf9077-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-7c4d363602860b50029c8f20f97b984d-3-2020-request
+++ b/public/requests/supp-7c4d363602860b50029c8f20f97b984d-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/public/requests/supp-a9c8580e2d8c1286bccb3b6565560f82-3-2020-request
+++ b/public/requests/supp-a9c8580e2d8c1286bccb3b6565560f82-3-2020-request
@@ -1,8 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid
-1,Repairs,Test mailerTest mailerTest mailerTest mailerTest mailerTest mailer,2020-03-09 13:09:13 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 15:40:28 UTC,2020-03-09 13:09:13 UTC,resolved,request-d34fc047e1968ac9ee96ac043fa283d3
-2,Repairs,Test mailer,2020-03-09 13:11:26 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:02:17 UTC,2020-03-09 13:11:26 UTC,resolved,request-9e1a58fc6154362c4424ce7fd5ecdc9e
-3,Repairs,Test mailer,2020-03-09 13:20:46 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:05:50 UTC,2020-03-09 13:20:46 UTC,resolved,request-9a8035f4074da88648655099a6c97a4e
-4,Tech,Tech,2020-03-09 13:23:40 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:32:36 UTC,2020-03-09 13:23:40 UTC,resolved,request-ed63ab46d588fe9f438c8f67c3e9710a
-5,Retro,Everything is broken,2020-03-09 13:26:05 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:36:58 UTC,2020-03-09 13:26:05 UTC,resolved,request-c9f3c5ae9ccf9a7abb1b9d3b21553fc0
-7,Retro,ret,2020-03-09 13:29:00 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:47:42 UTC,2020-03-09 15:21:05 UTC,assigned,request-ed21b355c219929c46cdb690611ad10a
-8,Tech,Tech,2020-03-09 13:37:45 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:49:09 UTC,2020-03-09 13:37:45 UTC,resolved,request-2e97ed35e3feb2fc9b47e320e17608ec

--- a/public/requests/supp-d8dab3dda2eeecc86bd3a0505dac3079-3-2020-request
+++ b/public/requests/supp-d8dab3dda2eeecc86bd3a0505dac3079-3-2020-request
@@ -1,8 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid
-1,Repairs,Test mailerTest mailerTest mailerTest mailerTest mailerTest mailer,2020-03-09 13:09:13 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 15:40:28 UTC,2020-03-09 13:09:13 UTC,resolved,request-d34fc047e1968ac9ee96ac043fa283d3
-2,Repairs,Test mailer,2020-03-09 13:11:26 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:02:17 UTC,2020-03-09 13:11:26 UTC,resolved,request-9e1a58fc6154362c4424ce7fd5ecdc9e
-3,Repairs,Test mailer,2020-03-09 13:20:46 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-02 16:05:50 UTC,2020-03-09 13:20:46 UTC,resolved,request-9a8035f4074da88648655099a6c97a4e
-4,Tech,Tech,2020-03-09 13:23:40 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:32:36 UTC,2020-03-09 13:23:40 UTC,resolved,request-ed63ab46d588fe9f438c8f67c3e9710a
-5,Retro,Everything is broken,2020-03-09 13:26:05 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:36:58 UTC,2020-03-09 13:26:05 UTC,resolved,request-c9f3c5ae9ccf9a7abb1b9d3b21553fc0
-7,Retro,ret,2020-03-09 13:29:00 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:47:42 UTC,2020-03-09 15:21:05 UTC,assigned,request-ed21b355c219929c46cdb690611ad10a
-8,Tech,Tech,2020-03-09 13:37:45 UTC,cust-5260c567787f47cc74158b272e9cdb8f,supp-4e9316af82f2249fd3e65b4c1714379c,2020-03-04 17:49:09 UTC,2020-03-09 13:37:45 UTC,resolved,request-2e97ed35e3feb2fc9b47e320e17608ec

--- a/public/requests/supp-f2ec56f917223e695bb45df0f2236c07-3-2020-request
+++ b/public/requests/supp-f2ec56f917223e695bb45df0f2236c07-3-2020-request
@@ -1,1 +1,0 @@
-id,subject,description,resolved_at,requester_id,assignee_id,created_at,updated_at,status,uid

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -26,4 +26,29 @@ RSpec.describe AdminMailer, type: :mailer do
     end
   end
 
+  describe "#no_available_agents" do
+    context "when the mailer is called" do
+      it "delivers the mail" do
+        expect do
+          AdminMailer
+            .with(support_request_id: support_request_id)
+            .no_available_agent
+            .deliver_later
+        end.to change(ActionMailer::Base.deliveries, :size).by 1
+      end
+
+      it "sends out the correct email body" do
+        email = AdminMailer
+          .with(support_request_id: support_request_id)
+          .no_available_agent
+        # binding.pry
+        admin_emails = Set.new(admins.pluck(:email))
+        to_emails = Set.new(email.to)
+        expect(to_emails).to eq admin_emails
+        expect(email.subject).to eq "No available agent"
+        expect(email.body.to_s).to include support_request_id
+      end
+    end
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/database_cleaner'
 require 'support/request_spec_helper'
+require "support/factory_bot"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/services/support_request_service_spec.rb
+++ b/spec/services/support_request_service_spec.rb
@@ -34,11 +34,12 @@ RSpec.describe SupportRequestService, type: :service do
 
   describe "assign_request" do
     context "when a support request is assigned" do
-      before { params[:assignee_id] = support_agent.id }
       it "returns the request with the assigned id" do
         sp = SupportRequestService
-               .new(request_params: params, support_request: support_request)
-               .assign_request
+               .new
+               .assign_request(
+                 assignee_id: support_agent.id, request_id: support_request.id
+               )
         expect(sp.assignee_id).to eq support_agent.id
         expect(sp.assignee_id).to eq SupportRequest.last.assignee_id
       end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/workers/assign_requests_worker_spec.rb
+++ b/spec/workers/assign_requests_worker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Tests for assign_requests_worker
+
+require "rails_helper"
+require "sidekiq/testing"
+require "sidekiq/extensions/action_mailer"
+
+RSpec.describe AssignRequestsWorker, type: :worker do
+  let!(:support_requests) { create_list(:support_request, 3) }
+  let!(:support_agents) { create_list(:support_agent, 3) }
+  let!(:admin) { create(:admin) }
+  before { ActionMailer::Base.deliveries.clear }
+
+  describe "#perform" do
+    context "when worker is called" do
+      it "pushes a job onto the queue" do
+        Sidekiq::Testing.fake!
+        expect do
+          AssignRequestsWorker.perform_async(support_requests.first[:id])
+        end.to change(AssignRequestsWorker.jobs, :size).by 1
+      end
+
+      it "sends out assigns the request" do
+        Sidekiq::Testing.inline! do
+          request = AssignRequestsWorker.new.perform(support_requests.first[:id])
+          expect(support_agents.pluck(:uid)).to include request.assignee_id
+        end
+      end
+    end
+
+    context "when there's no available agent" do
+      before do
+        support_agents.each { |agent| agent.update!(support_requests_count: 5) }
+      end
+      it "sends out a mail" do
+        mail = AssignRequestsWorker.new.perform(support_requests.first[:id])
+        expect(mail).to be_a_kind_of ActionMailer::MailDeliveryJob
+      end
+    end
+  end
+end

--- a/spec/workers/export_requests_worker_spec.rb
+++ b/spec/workers/export_requests_worker_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "sidekiq/testing"
 require "sidekiq/extensions/action_mailer"
 
-RSpec.describe SupportRequestWorker, type: :worker do
+RSpec.describe ExportRequestsWorker, type: :worker do
   let(:support_agent) { FactoryBot.create(:support_agent) }
   let!(:support_requests) { FactoryBot.create_list(:support_request, 5, assignee_id: support_agent.id) }
   before { ActionMailer::Base.deliveries.clear }
@@ -11,13 +11,13 @@ RSpec.describe SupportRequestWorker, type: :worker do
     it "pushes a job onto the queue" do
       Sidekiq::Testing.fake!
       expect do
-        SupportRequestWorker.perform_async(support_agent.id)
-      end.to change(SupportRequestWorker.jobs, :size).by 1
+        ExportRequestsWorker.perform_async(support_agent.id)
+      end.to change(ExportRequestsWorker.jobs, :size).by 1
     end
 
     it "sends a mail with requests out" do
       Sidekiq::Testing.inline! do
-        3.times { SupportRequestWorker.perform_async(support_agent.id) }
+        3.times { ExportRequestsWorker.perform_async(support_agent.id) }
         expect(ActionMailer::Base.deliveries.size).to eq 3
       end
     end


### PR DESCRIPTION
automatically assigns requests to an agent after creation

Test: when a request is created and there are available agents, it assigns it to one and sends them a mail. If none is available, it sends a mail to the admin

Assumption: agents can only have 5 requests automatically assigned to them at any time