### PR TITLE
Modify responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,6 @@ class ApplicationController < ActionController::API
 
     session ||= Session.active.find_by(uid: session_id)
     return unless session
-    session.update!(expires_at: session.expires_at + 24.hours)
+    session.update!(expires_at: session.expires_at + 1.hour)
   end
 end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,12 +1,12 @@
 module Response
-  def json_response(object:nil, extra: nil, status: :ok)
+  def json_response(object:nil, extra: nil, options: {}, status: :ok)
     if object.is_a? Hash
       object.transform_values! do |value|
-        ActiveModelSerializers::SerializableResource.new(value).as_json
+        ActiveModelSerializers::SerializableResource.new(value, options).as_json
       end
     end
 
-    object = ActiveModelSerializers::SerializableResource.new(object).as_json
+    object = ActiveModelSerializers::SerializableResource.new(object, options).as_json
     response = {
       data: object,
       extra: extra

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -10,6 +10,7 @@ class CustomersController < ApplicationController
         session_id: customer.sessions.last.id,
         expires_at: customer.sessions.last.expires_at
       },
+      options: { root: "user" },
       status: :created
     )
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,6 +27,12 @@ class SessionsController < ApplicationController
     json_response(object: @session)
   end
 
+  # fetch session using session ID in headers
+  def fetch_session
+    session = Session.find_by!(uid: request.headers['HTTP_SESSION_ID'])
+    json_response(object: session)#
+  end
+
   private
 
   def session_params

--- a/app/controllers/support_agents_controller.rb
+++ b/app/controllers/support_agents_controller.rb
@@ -6,13 +6,17 @@ class SupportAgentsController < ApplicationController
     support_agent.sessions.create!(user_agent: request.headers["HTTP_USER_AGENT"])
     json_response(
       object: support_agent,
-      extra: { session_id: support_agent.sessions.last.id },
+      extra: {
+        session_id: support_agent.sessions.last.id,
+        expires_at: support_agent.sessions.last.expires_at,
+      },
+      options: { root: "user" },
       status: :created
     )
   end
 
   def index
-    json_response(object: SupportAgent.all)
+    json_response(object: SupportAgent.all, options: { root: "users" })
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -15,6 +15,10 @@ class Session < ApplicationRecord
     super(class_name.constantize.base_class.to_s)
   end
 
+  def active?
+    expires_at > Time.current && deleted_at.nil?
+  end
+
   private
 
   def set_uid

--- a/app/serializers/customer_serializer.rb
+++ b/app/serializers/customer_serializer.rb
@@ -1,7 +1,7 @@
-class CustomerSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :phone_number
+class CustomerSerializer < UserSerializer
+  attributes :role
 
-  def id
-    object.uid
+  def role
+    "Customer"
   end
 end

--- a/app/serializers/support_agent_serializer.rb
+++ b/app/serializers/support_agent_serializer.rb
@@ -1,7 +1,10 @@
-class SupportAgentSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :phone_number
+# frozen_string_literal: true
 
-  def id
-    object.uid
+# SupportAgent Serializer
+class SupportAgentSerializer < UserSerializer
+  attributes :role
+
+  def role
+    "Support Agent"
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Base user serializer
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email, :phone_number, :role
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,5 @@ Rails.application.routes.draw do
   post "admins/login", to: "sessions#create"
   post "customers/login", to: "sessions#create"
   post "support_agents/login", to: "sessions#create"
+  get "/fetch_session", to: "sessions#fetch_session"
 end

--- a/lib/error/error_handler.rb
+++ b/lib/error/error_handler.rb
@@ -3,7 +3,9 @@ module Error
     def self.included(clazz)
       clazz.class_eval do
         rescue_from ActiveRecord::RecordNotFound do |e|
-          message = "#{e.model.underscore.humanize} was not found"
+          message = {
+            e.model.underscore.downcase.to_sym => "was not found"
+          }
           respond(:record_not_found, 404, message)
         end
         rescue_from ActiveRecord::RecordInvalid do |e|

--- a/lib/error/helpers/render.rb
+++ b/lib/error/helpers/render.rb
@@ -1,15 +1,7 @@
 module Error::Helpers
   class Render
     def self.json(error, status, messages)
-      {
-        errors: [
-          {
-            status: status,
-            error: error,
-            messages: messages
-          }
-        ]
-      }.as_json
+      { errors: [messages] }.as_json
     end
 
     def self.json_invalid_record(messages)

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AdminsController, type: :request do
       it "returns an error" do
         errors = json["errors"].first
         expect(response).to have_http_status 404
-        expect(errors["messages"]).to eq "Support agent was not found"
+        expect(errors["support_agent"]).to eq "was not found"
       end
     end
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe CommentsController, type: :request do
         get support_request_comments_path(support_request.id)
         errors = json["errors"].first
         expect(response).to have_http_status 404
-        expect(errors["messages"]).to eq "Session was not found"
+        expect(errors["session"]).to eq "was not found"
       end
     end
   end

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe CustomersController do
       before { post customers_path, params: customer }
 
       it "returns the created customer" do
-        saved_customer = json["data"]["customer"]
+        saved_customer = json["data"]["user"]
         expect(response).to have_http_status 201
         expect(saved_customer["name"]).to eq customer[:name]
         expect(saved_customer["email"]).to eq customer[:email]
+        expect(saved_customer["role"]).to eq "Customer"
         expect(saved_customer["phone_number"]).to eq customer[:phone_number]
       end
     end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SessionsController, type: :request do
 
       it "returns an error" do
         expect(response).to have_http_status 404
-        expect(json["errors"].first["messages"]).to eq "Session was not found"
+        expect(json["errors"].first["session"]).to eq "was not found"
       end
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe SessionsController, type: :request do
 
       it "returns an error" do
         expect(response).to have_http_status 404
-        expect(json["errors"].first["messages"]).to eq "Session was not found"
+        expect(json["errors"].first["session"]).to eq "was not found"
       end
     end
   end
@@ -97,6 +97,19 @@ RSpec.describe SessionsController, type: :request do
       customer_ids = json["data"]["sessions"].pluck("user_id").uniq
       expect(customer_ids.count).to eq 1
       expect(customer_ids).to include list_customer.id
+    end
+  end
+
+  describe "#fetch_session" do
+    let!(:list_customer) { create(:customer_with_sessions) }
+    let(:list_session_id) { list_customer.sessions.first.id }
+    context "when request is made" do
+      before do
+        get fetch_session_path, headers: authenticated_headers(list_session_id)
+      end
+      # it "returns the user", focus: true do
+      #   binding.pry
+      # end
     end
   end
 end

--- a/spec/requests/support_agents_spec.rb
+++ b/spec/requests/support_agents_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe SupportAgentsController do
       end
 
       it "returns the created support_agent" do
-        saved_support_agent = json["data"]["support_agent"]
+        saved_support_agent = json["data"]["user"]
         expect(response).to have_http_status 201
         expect(saved_support_agent["name"]).to eq support_agent[:name]
         expect(saved_support_agent["email"]).to eq support_agent[:email]
         expect(saved_support_agent["phone_number"]).to eq support_agent[:phone_number]
+        expect(saved_support_agent["role"]).to eq "Support Agent"
       end
     end
 
@@ -95,7 +96,7 @@ RSpec.describe SupportAgentsController do
     context "when admin tries to access a list of support agents" do
       before { get support_agents_path, headers: authenticated_headers(admin_session.id) }
       it "returns a list of available support agents" do
-        support_agents = json["data"]["support_agents"]
+        support_agents = json["data"]["users"]
         expect(response).to have_http_status 200
         expect(support_agents.count).to eq 5
         expect(support_agents.first["name"]).to eq agents.first.name

--- a/spec/requests/support_requests_spec.rb
+++ b/spec/requests/support_requests_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SupportRequestsController, type: :request do
 
       it "returns an not found error" do
         expect(response).to have_http_status 404
-        expect(json["errors"].first["messages"]).to eq "Session was not found"
+        expect(json["errors"].first["session"]).to eq "was not found"
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe SupportRequestsController, type: :request do
       it "returns an error" do
         errors = json["errors"].first
         expect(response).to have_http_status 404
-        expect(errors["messages"]).to eq "Support request was not found"
+        expect(errors["support_request"]).to eq "was not found"
       end
     end
   end


### PR DESCRIPTION
#### What does this PR do?
Modify some of the API responses
#### Description of Task to be completed?
* Add `session_id` and `expires_at` to response when creating new customer and support agent
* Change root key to `user(s)` when returning customers/admins/support agents
* Refresh session by adding an extra hour instead of 24
* Create parent serializer for all user classes
* Modify error message displayed for `404` cases
#### How should this be manually tested?
Sending a request to fetch a customer or support agent should have the root key shown as `user`
#### Any background context you want to provide?
N/A